### PR TITLE
feat: 관리자 정보 수정 기능 추가 (주차장 정보 수정 + 관리자 전화번호 수정)

### DIFF
--- a/src/main/java/com/tikkeul/mote/controller/AdminController.java
+++ b/src/main/java/com/tikkeul/mote/controller/AdminController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import com.tikkeul.mote.dto.AdminLoginRequest;
 import com.tikkeul.mote.dto.AdminSignupRequest;
 import com.tikkeul.mote.dto.BusinessVerificationRequest;
-import com.tikkeul.mote.dto.ParkingLotUpdateRequest;
+import com.tikkeul.mote.dto.AdminInfoUpdateRequest;
 import com.tikkeul.mote.service.AdminService;
 import com.tikkeul.mote.service.BusinessVerificationService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -68,14 +68,14 @@ public class AdminController {
         }
     }
 
-    @PatchMapping("/update-parking-lot")
-    public ResponseEntity<?> updateParkingLot(
+    @PatchMapping("/update-admin-info")
+    public ResponseEntity<?> updateAdminInfo(
             @AuthenticationPrincipal AdminDetails adminDetails,
-            @RequestBody ParkingLotUpdateRequest request
+            @RequestBody AdminInfoUpdateRequest request
     ) {
         try {
-            adminService.updateParkingLot(adminDetails.getAdmin(), request);
-            return ResponseEntity.ok("주차장 정보가 수정되었습니다.");
+            adminService.updateAdminInfo(adminDetails.getAdmin(), request);
+            return ResponseEntity.ok("회원 정보가 수정되었습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(500).body("수정 실패: " + e.getMessage());
         }

--- a/src/main/java/com/tikkeul/mote/dto/AdminInfoUpdateRequest.java
+++ b/src/main/java/com/tikkeul/mote/dto/AdminInfoUpdateRequest.java
@@ -6,7 +6,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ParkingLotUpdateRequest {
+public class AdminInfoUpdateRequest {
+    private String phoneNumber;
     private Integer basePrice;
     private Integer pricePerMinute;
     private Integer totalLot;

--- a/src/main/java/com/tikkeul/mote/entity/Park.java
+++ b/src/main/java/com/tikkeul/mote/entity/Park.java
@@ -6,9 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "park", uniqueConstraints = {
-        @UniqueConstraint(columnNames = "plate")
-})
+@Table(name = "park")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/tikkeul/mote/service/AdminService.java
+++ b/src/main/java/com/tikkeul/mote/service/AdminService.java
@@ -1,7 +1,7 @@
 package com.tikkeul.mote.service;
 
 import com.tikkeul.mote.dto.AdminSignupRequest;
-import com.tikkeul.mote.dto.ParkingLotUpdateRequest;
+import com.tikkeul.mote.dto.AdminInfoUpdateRequest;
 import com.tikkeul.mote.entity.Admin;
 import com.tikkeul.mote.entity.ParkingLot;
 import com.tikkeul.mote.repository.AdminRepository;
@@ -81,17 +81,43 @@ public class AdminService {
         redisTemplate.delete("verify:" + phoneNumber);
     }
 
-    public void updateParkingLot(Admin admin, ParkingLotUpdateRequest request) {
+    public void updateParkingLot(Admin admin, AdminInfoUpdateRequest request) {
         ParkingLot parkingLot = parkingLotRepository.findByAdmin(admin)
                 .orElseThrow(() -> new IllegalStateException("주차장 정보를 찾을 수 없습니다."));
 
         if (request.getBasePrice() != null) {
-            parkingLot.setBasePrice(request.getBasePrice()); // ✅ 기본요금 업데이트
+            parkingLot.setBasePrice(request.getBasePrice()); // 기본요금 업데이트
         }
 
         if (request.getPricePerMinute() != null) {
             parkingLot.setPricePerMinute(request.getPricePerMinute());
         }
+        if (request.getTotalLot() != null) {
+            parkingLot.setTotalLot(request.getTotalLot());
+        }
+
+        parkingLotRepository.save(parkingLot);
+    }
+
+    public void updateAdminInfo(Admin admin, AdminInfoUpdateRequest request) {
+        // 관리자 전화번호 업데이트
+        if (request.getPhoneNumber() != null && !request.getPhoneNumber().isBlank()) {
+            admin.setPhoneNumber(request.getPhoneNumber());
+            adminRepository.save(admin);
+        }
+
+        // 주차장 정보 업데이트
+        ParkingLot parkingLot = parkingLotRepository.findByAdmin(admin)
+                .orElseThrow(() -> new IllegalStateException("주차장 정보를 찾을 수 없습니다."));
+
+        if (request.getBasePrice() != null) {
+            parkingLot.setBasePrice(request.getBasePrice());
+        }
+
+        if (request.getPricePerMinute() != null) {
+            parkingLot.setPricePerMinute(request.getPricePerMinute());
+        }
+
         if (request.getTotalLot() != null) {
             parkingLot.setTotalLot(request.getTotalLot());
         }


### PR DESCRIPTION
기존의 주차장 정보 수정 기능에서 관리자의 전화번호를 수정할 수 있는 기능을 넣어 관리자 정보 수정으로 발전시킴.
추가적으로 Park 테이블의 plate 속성의 unique 제약을 빼서, ocr이 차량을 인식하지 못해 not_found로 처리하는 건 수가 많아져도 이를 처리할 수 있게 수정함.