### PR TITLE
feat: 정기권 이력 기능 추가

### DIFF
--- a/src/main/java/com/tikkeul/mote/MoteApplication.java
+++ b/src/main/java/com/tikkeul/mote/MoteApplication.java
@@ -3,9 +3,11 @@ package com.tikkeul.mote;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class MoteApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/tikkeul/mote/controller/SubscriptionHistoryController.java
+++ b/src/main/java/com/tikkeul/mote/controller/SubscriptionHistoryController.java
@@ -1,0 +1,34 @@
+package com.tikkeul.mote.controller;
+
+import com.tikkeul.mote.dto.SubscriptionHistoryResponse;
+import com.tikkeul.mote.security.AdminDetails;
+import com.tikkeul.mote.service.SubscriptionHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sub-history")
+@RequiredArgsConstructor
+public class SubscriptionHistoryController {
+
+    private final SubscriptionHistoryService subscriptionHistoryService;
+
+    @GetMapping
+    public ResponseEntity<List<SubscriptionHistoryResponse>> getHistories(
+            @AuthenticationPrincipal AdminDetails adminDetails,
+            @RequestParam("startDate") LocalDate startDate,
+            @RequestParam("endDate") LocalDate endDate,
+            @RequestParam(value = "plate", required = false) String plate) {
+
+        List<SubscriptionHistoryResponse> histories = subscriptionHistoryService.getHistories(adminDetails.getAdmin(), startDate, endDate, plate);
+        return ResponseEntity.ok(histories);
+    }
+}

--- a/src/main/java/com/tikkeul/mote/dto/DailyStatsResponse.java
+++ b/src/main/java/com/tikkeul/mote/dto/DailyStatsResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 public class DailyStatsResponse {
     private final LocalDate date;          // 날짜
     private final int totalRevenue;      // 해당일의 총 매출
+    private final int subscriptionRevenue;
     private final int totalEntries;      // 해당일의 총 입차 대수
     private final int totalExits;        // 해당일의 총 출차 대수
 }

--- a/src/main/java/com/tikkeul/mote/dto/ParkResponse.java
+++ b/src/main/java/com/tikkeul/mote/dto/ParkResponse.java
@@ -38,7 +38,7 @@ public class ParkResponse {
 
         // 정기권 차량 여부에 따라 요금 포맷팅
         if (isSubscription) {
-            formattedFee = "정기권"; // 정기권 차량은 "정기권"으로 표시
+            formattedFee = "0원"; // 정기권 차량은 "정기권"으로 표시
         } else {
             // 요금 계산: 기본요금 + 분당요금 * 분
             if (totalMinutes > 0) {

--- a/src/main/java/com/tikkeul/mote/dto/StatsResponse.java
+++ b/src/main/java/com/tikkeul/mote/dto/StatsResponse.java
@@ -12,6 +12,7 @@ public class StatsResponse {
     private final LocalDate startDate;     // 시작일
     private final LocalDate endDate;       // 종료일
     private final long totalRevenue;     // 기간 내 총 매출
+    private final long totalSubscriptionRevenue;
     private final long totalEntries;     // 기간 내 총 입차
     private final long totalExits;       // 기간 내 총 출차
     private final List<DailyStatsResponse> dailyStats; // 일자별 상세 통계

--- a/src/main/java/com/tikkeul/mote/dto/SubscriptionHistoryResponse.java
+++ b/src/main/java/com/tikkeul/mote/dto/SubscriptionHistoryResponse.java
@@ -1,0 +1,29 @@
+package com.tikkeul.mote.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tikkeul.mote.entity.SubscriptionHistory;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class SubscriptionHistoryResponse {
+
+    private final Long id;
+    private final String plate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private final LocalDate endDate;
+    private final String price;
+    private final String memo;
+
+    public SubscriptionHistoryResponse(SubscriptionHistory history) {
+        this.id = history.getSubHistoryId();
+        this.plate = history.getSubHistoryPlate();
+        this.startDate = history.getHistoryStartDate();
+        this.endDate = history.getHistoryEndDate();
+        this.price = String.format("%,d원", history.getSubHistoryPrice());
+        this.memo = history.getHistoryMemo();
+    }
+}

--- a/src/main/java/com/tikkeul/mote/entity/SubscriptionHistory.java
+++ b/src/main/java/com/tikkeul/mote/entity/SubscriptionHistory.java
@@ -1,0 +1,39 @@
+package com.tikkeul.mote.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "sub_history")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriptionHistory {
+
+    @Id
+    @Column(name = "sub_history_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long subHistoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Admin admin;
+
+    @Column(name = "sub_history_plate", nullable = false, length = 50)
+    private String subHistoryPlate;
+
+    @Column(name = "history_startDate", nullable = false)
+    private LocalDate historyStartDate;
+
+    @Column(name = "history_endDate", nullable = false)
+    private LocalDate historyEndDate;
+
+    @Column(name = "sub_history_price")
+    private int subHistoryPrice;
+
+    @Column(name = "history_memo", length = 500)
+    private String historyMemo;
+}

--- a/src/main/java/com/tikkeul/mote/repository/SubscriptionHistoryRepository.java
+++ b/src/main/java/com/tikkeul/mote/repository/SubscriptionHistoryRepository.java
@@ -1,0 +1,17 @@
+package com.tikkeul.mote.repository;
+
+import com.tikkeul.mote.entity.Admin;
+import com.tikkeul.mote.entity.SubscriptionHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface SubscriptionHistoryRepository extends JpaRepository<SubscriptionHistory, Long> {
+
+    List<SubscriptionHistory> findByAdminAndHistoryStartDateBetween(Admin admin, LocalDate start, LocalDate end);
+    List<SubscriptionHistory> findByAdminAndHistoryStartDateBetweenOrderByHistoryStartDateDesc(Admin admin, LocalDate start, LocalDate end);
+    List<SubscriptionHistory> findByAdminAndHistoryStartDateBetweenAndSubHistoryPlateContainingOrderByHistoryStartDateDesc(Admin admin, LocalDate start, LocalDate end, String plateKeyword);
+}

--- a/src/main/java/com/tikkeul/mote/repository/SubscriptionRepository.java
+++ b/src/main/java/com/tikkeul/mote/repository/SubscriptionRepository.java
@@ -16,4 +16,5 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     boolean existsByAdminAndSubPlateAndEndDateAfter(Admin admin, String subPlate, LocalDate date);
     long deleteByAdmin(Admin admin);
     long countByAdmin(Admin admin);
+    void deleteByEndDateBefore(LocalDate date);
 }

--- a/src/main/java/com/tikkeul/mote/service/SubscriptionCleanupService.java
+++ b/src/main/java/com/tikkeul/mote/service/SubscriptionCleanupService.java
@@ -1,0 +1,29 @@
+package com.tikkeul.mote.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionCleanupService {
+
+    private final SubscriptionService subscriptionService;
+
+    // 매일 자정에 만료된 정기권을 삭제하도록 SubscriptionService를 호출
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void scheduledCleanup() {
+        System.out.println("스케줄러 실행: 만료된 정기권 정리를 시작합니다...");
+        subscriptionService.cleanupExpiredSubscriptions();
+    }
+
+    // 애플리케이션이 완전히 시작된 후, 만료된 정기권 정리를 위해 SubscriptionService를 호출
+    @EventListener(ApplicationReadyEvent.class)
+    public void startupCleanup() {
+        System.out.println("서버가 완전히 준비되었습니다. 밀린 만료 정기권을 정리합니다...");
+        subscriptionService.cleanupExpiredSubscriptions();
+    }
+}

--- a/src/main/java/com/tikkeul/mote/service/SubscriptionHistoryService.java
+++ b/src/main/java/com/tikkeul/mote/service/SubscriptionHistoryService.java
@@ -1,0 +1,36 @@
+package com.tikkeul.mote.service;
+
+import com.tikkeul.mote.dto.SubscriptionHistoryResponse;
+import com.tikkeul.mote.entity.Admin;
+import com.tikkeul.mote.entity.SubscriptionHistory;
+import com.tikkeul.mote.repository.SubscriptionHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionHistoryService {
+
+    private final SubscriptionHistoryRepository subscriptionHistoryRepository;
+
+    public List<SubscriptionHistoryResponse> getHistories(Admin admin, LocalDate startDate, LocalDate endDate, String keyword) {
+        List<SubscriptionHistory> histories;
+
+        // 차량 번호 검색어가 있는지 없는지에 따라 다른 메소드 호출
+        if (keyword == null || keyword.isBlank()) {
+            // 기간으로만 조회
+            histories = subscriptionHistoryRepository.findByAdminAndHistoryStartDateBetweenOrderByHistoryStartDateDesc(admin, startDate, endDate);
+        } else {
+            // 기간 + 차량 번호로 조회
+            histories = subscriptionHistoryRepository.findByAdminAndHistoryStartDateBetweenAndSubHistoryPlateContainingOrderByHistoryStartDateDesc(admin, startDate, endDate, keyword);
+        }
+
+        return histories.stream()
+                .map(SubscriptionHistoryResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/tikkeul/mote/service/SubscriptionService.java
+++ b/src/main/java/com/tikkeul/mote/service/SubscriptionService.java
@@ -3,11 +3,14 @@ package com.tikkeul.mote.service;
 import com.tikkeul.mote.dto.SubscriptionRequest;
 import com.tikkeul.mote.entity.Admin;
 import com.tikkeul.mote.entity.Subscription;
+import com.tikkeul.mote.entity.SubscriptionHistory;
+import com.tikkeul.mote.repository.SubscriptionHistoryRepository;
 import com.tikkeul.mote.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,7 +19,9 @@ import java.util.Optional;
 public class SubscriptionService {
 
     private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionHistoryRepository subscriptionHistoryRepository;
 
+    @Transactional
     public Subscription addSubscription(Admin admin, SubscriptionRequest request) {
         // 중복 등록 확인
         subscriptionRepository.findByAdminAndSubPlate(admin, request.getSubPlate()).ifPresent(s -> {
@@ -31,7 +36,10 @@ public class SubscriptionService {
                 .subPrice(request.getSubPrice())
                 .memo(request.getMemo())
                 .build();
-        return subscriptionRepository.save(subscription);
+
+        Subscription savedSubscription = subscriptionRepository.save(subscription);
+        saveSubscriptionHistory(savedSubscription); // 등록 시 이력 테이블에 저장
+        return savedSubscription;
     }
 
     public List<Subscription> getSubscriptions(Admin admin) {
@@ -54,6 +62,7 @@ public class SubscriptionService {
         });
     }
 
+    @Transactional
     public void removeSubscription(Long id, Admin admin) {
         Subscription subscription = subscriptionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 항목이 존재하지 않습니다."));
@@ -86,5 +95,24 @@ public class SubscriptionService {
             throw new IllegalStateException("삭제할 항목이 없습니다.");
         }
         subscriptionRepository.deleteByAdmin(admin);
+    }
+
+    @Transactional
+    public void cleanupExpiredSubscriptions() {
+        LocalDate today = LocalDate.now();
+        subscriptionRepository.deleteByEndDateBefore(today);
+        System.out.println("만료된 정기권 정리 완료.");
+    }
+
+    private void saveSubscriptionHistory(Subscription subscription) {
+        SubscriptionHistory history = SubscriptionHistory.builder()
+                .admin(subscription.getAdmin())
+                .subHistoryPlate(subscription.getSubPlate())
+                .historyStartDate(subscription.getStartDate())
+                .historyEndDate(subscription.getEndDate())
+                .subHistoryPrice(subscription.getSubPrice())
+                .historyMemo(subscription.getMemo())
+                .build();
+        subscriptionHistoryRepository.save(history);
     }
 }

--- a/src/main/java/com/tikkeul/mote/service/VisitorService.java
+++ b/src/main/java/com/tikkeul/mote/service/VisitorService.java
@@ -125,7 +125,10 @@ public class VisitorService {
         String feeStr = String.format("%,d원", totalFee);
         String timestampStr = entered.format(TS_FMT);
 
-        String address = kakaoMapService.getAddressFromCoordinates(park.getLatitude(), park.getLongitude());
+        String address = "주소 정보 없음"; // 기본값을 설정합니다.
+        if (park.getLatitude() != null && park.getLongitude() != null) {
+            address = kakaoMapService.getAddressFromCoordinates(park.getLatitude(), park.getLongitude());
+        }
 
         return VisitorParkInfoResponse.builder()
                 .plate(park.getPlate())


### PR DESCRIPTION
1. 정기권 이력 엔티티 생성
   (속성: ID, 차량번호, 시작일, 종료일, 가격, 메모)
   (정기권 등록 시, 정기권 이력에 저장)
2. 정기권 이력 조회 기능 추가 
   (startDate, endDate, plate(선택) 으로 조회 가능)
3. 정기권 만료 시 자동 삭제 기능 추가
4. 정기권 매출 통계에 추가, 정기권 매출 - 일반 차량 매출 분리